### PR TITLE
fix: constrain package discovery metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
-from setuptools import setup
+from setuptools import find_packages, setup
 
 import talkbot
 
 setup(
     name="talkbot",
     version=talkbot.__version__,
+    packages=find_packages(include=["talkbot", "talkbot.*"]),
+    python_requires=">=3.10,<3.11",
 )


### PR DESCRIPTION
## Summary
- make setuptools package discovery explicit for 	alkbot`n- add the declared Python support range to packaging metadata

## Verification
- python -m pip install -e . --no-deps now reaches the Python-version gate instead of failing package discovery

## Scope
- packaging metadata only
- no runtime logic changes